### PR TITLE
fixed atcoder url problem

### DIFF
--- a/app/Contest.js
+++ b/app/Contest.js
@@ -12,7 +12,11 @@ class Contest {
     this.startTime = startTime;
     this.endTime = endTime;
     this.platform = platform;
-    this.url = url;
+    if (platform === 'atcoder') {
+      this.url = 'https://atcoder.jp' + url;
+    } else {
+      this.url = url;
+    }
   }
 
   getID() {


### PR DESCRIPTION
Issue #24. The API wasn't giving the full url for atcoder contests, which resulted in atcoder contests not opening. For example: /contests/arc109 instead of https://atcoder.jp/contests/arc109.